### PR TITLE
Handle pure EMU repos and dirty trees in update.sh

### DIFF
--- a/bin/update.sh
+++ b/bin/update.sh
@@ -1,15 +1,42 @@
+#!/usr/bin/env bash
+# Update every repo in the current directory that sits on master/main.
+# Clean trees are pulled; dirty trees are only fetched (never merged).
+# Pure (Enterprise Managed User) repos — origin like org-XXXXXXX@github.com —
+# are handled specially: configure them with purerepo when unset, skip when
+# they carry a foreign user.email, pull/fetch when already the pure identity.
+
+PURE_EMAIL="lprskavec@purestorage.com"
+
 for name in */ ; do
-  if [ -d "$name" ] && [ ! -L "$name" ]; then
-    cd $name
-    if [ -d ".git" ]; then
-      BRANCH=`git branch --no-color | grep -e "^*" | tr -d ' *'`      
-      if [ "$BRANCH" == "master" ] || [ "$BRANCH" == "main" ]; then
-        if git remote | grep origin > /dev/null; then
-          printf 'Update source in directory: %s\n' "$name"        
-          git pull
-        fi
+  [ -d "$name" ] && [ ! -L "$name" ] || continue
+  (
+    cd "$name" || exit
+    [ -e ".git" ] || exit
+
+    branch=$(git branch --no-color | grep -e "^*" | tr -d ' *')
+    [ "$branch" = "master" ] || [ "$branch" = "main" ] || exit
+    git remote | grep -q origin || exit
+
+    origin=$(git remote get-url origin 2>/dev/null)
+
+    # EMU / pure repo: origin looks like org-144335849@github.com:...
+    if printf '%s' "$origin" | grep -qE '^org-[0-9]+@github\.com'; then
+      email=$(git config --get user.email)
+      if [ -z "$email" ]; then
+        printf 'Configuring pure repo: %s\n' "$name"
+        purerepo
+      elif [ "$email" != "$PURE_EMAIL" ]; then
+        printf 'Skipping (foreign user.email=%s): %s\n' "$email" "$name"
+        exit
       fi
     fi
-    cd ..
-  fi 
+
+    if [ -n "$(git status --porcelain)" ]; then
+      printf 'Local changes, fetching only: %s\n' "$name"
+      git fetch
+    else
+      printf 'Update source in directory: %s\n' "$name"
+      git pull
+    fi
+  )
 done


### PR DESCRIPTION
Reworks `bin/update.sh` to handle Pure (Enterprise Managed User) repos and dirty working trees, plus the robustness fixes flagged during review.

**Pure / EMU repo handling** — when `origin` looks like `org-XXXXXXX@github.com:...`:
- `user.email` unset → run `purerepo` to configure name/email + Vault SSH cert, then update.
- `user.email` is `lprskavec@purestorage.com` → update normally.
- `user.email` is a different address → skip the repo.

**Dirty trees** — if `git status --porcelain` is non-empty, `git fetch` only (never merge). Clean trees still `git pull`.

**Robustness fixes**
- Quote `"$name"` (was unquoted — broke on spaces).
- Run each repo in a subshell so a failed `cd` can't walk the wrong tree.
- Detect `.git` as a file or dir (`-e`), covering worktrees/submodules.
- Add `#!/usr/bin/env bash` shebang.

Verified with a non-mutating dry-run across `~/Sites/krypton` (84 repos): pure repos with empty email route to `purerepo`, dirty repos to `fetch`, clean master/main repos to `pull`, and feature-branch / remote-less dirs are skipped — matching the original behavior where it should.
