### PR TITLE
Run purerepo when pure repo is missing core.sshCommand

### DIFF
--- a/bin/update.sh
+++ b/bin/update.sh
@@ -28,6 +28,9 @@ for name in */ ; do
       elif [ "$email" != "$PURE_EMAIL" ]; then
         printf 'Skipping (foreign user.email=%s): %s\n' "$email" "$name"
         exit
+      elif [ -z "$(git config --get core.sshCommand)" ]; then
+        printf 'Fixing missing core.sshCommand: %s\n' "$name"
+        purerepo
       fi
     fi
 


### PR DESCRIPTION
update.sh already runs `purerepo` on pure (EMU) repos that have no `user.email`. This adds one more case: when the repo already carries the pure identity but is missing `core.sshCommand`, run `purerepo` to configure it (Vault SSH cert). Foreign-email repos are still skipped.