### PR TITLE
Add cmd+b Ghostty keybind for Herdr prefix

### DIFF
--- a/ghostty/config
+++ b/ghostty/config
@@ -1187,6 +1187,7 @@ keybind = super+k=clear_screen
 keybind = super+physical:two=goto_tab:2
 keybind = super+physical:six=goto_tab:6
 keybind = super+v=paste_from_clipboard
+keybind = cmd+b=text:\x02
 
 # Horizontal window padding. This applies padding between the terminal cells
 # and the left and right window borders. The value is in points, meaning that


### PR DESCRIPTION
Adds a Ghostty keybind so ⌘B sends Ctrl-B (`\x02`), the Herdr multiplexer prefix key.

```
keybind = cmd+b=text:\x02
```

Reload the Ghostty config (or restart) to apply.