### PR TITLE
Add hnew: Herdr workspace with agent + terminal tabs

### DIFF
--- a/bash/aliases
+++ b/bash/aliases
@@ -562,3 +562,19 @@ klod() {
     done
     CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1 claude "${args[@]}" "$@"
 }
+
+# Herdr: new workspace with two tabs - agent + terminal
+# Usage: hnew [label] [agent]    e.g.  hnew review claude
+hnew() {
+  if [ "${HERDR_ENV:-}" != 1 ]; then
+    echo "hnew: not running inside Herdr" >&2
+    return 1
+  fi
+  local label="${1:-work}" agent="${2:-claude}" ws agent_pane
+  agent_pane=$(herdr workspace create --label "$label" --focus | jq -r '.result.root_pane.pane_id')
+  ws=${agent_pane%%:*}
+  herdr tab create --workspace "$ws" --label "terminal" --no-focus >/dev/null
+  herdr tab rename "${ws}:t1" "agent" >/dev/null
+  herdr pane run "$agent_pane" "$agent"
+  echo "workspace=$ws  agent-tab=${ws}:t1  terminal-tab=${ws}:t2"
+}


### PR DESCRIPTION
Adds a `hnew` shell function that automates creating a new Herdr workspace with two full-screen tabs: one running a coding agent and one plain terminal.

**Usage**

```
hnew [label] [agent]
```

- `label` — workspace label (default: `work`)
- `agent` — agent executable to launch in tab 1 (default: `claude`; also `codex`, `pi`, `opencode`, `omp`)

**What it does**

1. Creates a workspace and focuses it.
2. Reads the workspace's first pane, renames tab 1 to `agent`, and launches the agent there.
3. Adds a second tab `terminal` with a plain shell.

Two full-screen tabs instead of split panes — better for smaller screens. Guards on `HERDR_ENV=1` and needs `jq`. Verified end-to-end: creates the workspace, both tabs, and runs the command in the agent tab.
