### PR TITLE
Route cmd+shift+[/] to Herdr tab nav via prefix

### DIFF
--- a/ghostty/config
+++ b/ghostty/config
@@ -1123,7 +1123,7 @@ keybind = super+ctrl+equal=equalize_splits
 keybind = super+physical:four=goto_tab:4
 keybind = super+shift+down=jump_to_prompt:1
 keybind = super+shift+w=close_window
-keybind = super+shift+left_bracket=previous_tab
+keybind = super+shift+left_bracket=text:\x02p
 keybind = super+alt+i=inspector:toggle
 keybind = super+w=close_surface
 keybind = super+physical:eight=goto_tab:8
@@ -1133,7 +1133,7 @@ keybind = super+down=jump_to_prompt:1
 keybind = super+enter=toggle_fullscreen
 keybind = super+t=new_tab
 keybind = super+c=copy_to_clipboard
-keybind = super+shift+right_bracket=next_tab
+keybind = super+shift+right_bracket=text:\x02n
 keybind = super+physical:one=goto_tab:1
 keybind = shift+left=adjust_selection:left
 keybind = super+equal=increase_font_size:1


### PR DESCRIPTION
Maps `cmd+shift+[` / `cmd+shift+]` to Herdr's tab navigation.

Both keys were previously bound to Ghostty's own `previous_tab` / `next_tab`, which consumed them so they never reached Herdr. Now Ghostty translates them into Herdr's default prefix actions:

- `cmd+shift+[` -> `text:\x02p` (Ctrl-B p = Herdr previous tab)
- `cmd+shift+]` -> `text:\x02n` (Ctrl-B n = Herdr next tab)

Same translation pattern as the existing `cmd+b=text:\x02` prefix forward. No Herdr config change required. Ghostty's own tabs remain switchable via `ctrl+tab` / `ctrl+shift+tab`.
