### PR TITLE
Add CMD+SHIFT+arrow Herdr workspace navigation

### DIFF
--- a/ghostty/config
+++ b/ghostty/config
@@ -1121,7 +1121,7 @@ working-directory =
 keybind = super+page_up=scroll_page_up
 keybind = super+ctrl+equal=equalize_splits
 keybind = super+physical:four=goto_tab:4
-keybind = super+shift+down=jump_to_prompt:1
+keybind = super+shift+down=text:\x02\x1b[B
 keybind = super+shift+w=close_window
 keybind = super+shift+left_bracket=text:\x02p
 keybind = super+alt+i=inspector:toggle
@@ -1151,7 +1151,7 @@ keybind = super+ctrl+left=resize_split:left,10
 keybind = alt+left=esc:b
 keybind = super+ctrl+up=resize_split:up,10
 keybind = super+left=text:\x01
-keybind = super+shift+up=jump_to_prompt:-1
+keybind = super+shift+up=text:\x02\x1b[A
 keybind = shift+right=adjust_selection:right
 keybind = super+comma=open_config
 keybind = super+shift+comma=reload_config

--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -1,5 +1,10 @@
 onboarding = false
 
+[theme.custom]
+# surface_dim colors the sidebar/main divider line; the catppuccin default
+# (#1e1e2e) matches the terminal background, making the divider invisible.
+surface_dim = "#313244"
+
 [keys]
 previous_workspace = "prefix+up"
 next_workspace = "prefix+down"

--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -1,0 +1,10 @@
+onboarding = false
+
+[keys]
+previous_workspace = "prefix+up"
+next_workspace = "prefix+down"
+
+[[keys.command]]
+key = "cmd+p"
+type = "shell"
+command = "herdr plugin action invoke cloudmanic.herdr-plus.projects"

--- a/install
+++ b/install
@@ -67,6 +67,7 @@ atuin/config.toml|.config/atuin/config.toml
 ghostty/config|.config/ghostty/config
 ghostty/themes/catppuccin-mocha.conf|.config/ghostty/themes/catppuccin-mocha.conf
 helix/config.toml|.config/helix/config.toml
+herdr/config.toml|.config/herdr/config.toml
 hunk/config.toml|.config/hunk/config.toml
 lsd/colors.yaml|.config/lsd/colors.yaml
 lsd/config.yaml|.config/lsd/config.yaml

--- a/install
+++ b/install
@@ -13,6 +13,10 @@ link() {
     status=1
   elif [ -L "$target" ] && [ "$(readlink "$target")" = "$source" ]; then
     printf 'ok       %s\n' "$target"
+  elif [ -e "$target" ] && [ "$(stat -Lf '%d:%i' "$target")" = "$(stat -Lf '%d:%i' "$source")" ]; then
+    # Target already resolves to the source (e.g. via a parent directory
+    # symlink). Treat as linked rather than a conflict.
+    printf 'ok       %s (resolves to source)\n' "$target"
   elif [ -e "$target" ] || [ -L "$target" ]; then
     printf 'conflict %s (move it aside and rerun)\n' "$target" >&2
     status=1


### PR DESCRIPTION
Bind CMD+SHIFT+Up / CMD+SHIFT+Down to switch Herdr workspaces (spaces), mirroring the existing CMD+SHIFT+[ / CMD+SHIFT+] tab navigation.

**Ghostty** (`ghostty/config`): `super+shift+up` / `super+shift+down` now send the Herdr prefix (Ctrl-B) plus Up/Down (`text:\x02\x1b[A` / `text:\x02\x1b[B`) instead of `jump_to_prompt`.

**Herdr** (`herdr/config.toml`, newly tracked): binds `previous_workspace = "prefix+up"` and `next_workspace = "prefix+down"`. Added to the `install` manifest so it symlinks like the other configs.

**install**: `link()` now treats a target that already resolves to the source (e.g. through a parent directory symlink, as with the legacy `~/.config/ghostty` dir link) as `ok` instead of a false `conflict`, so the script stays idempotent.

Verified: `herdr config check` passes; `herdr server reload-config` applied with no diagnostics; `sh install` reports `ok` for both configs. Ghostty must be reloaded (CMD+SHIFT+,) for its keybinds to take effect.
