### PR TITLE
Add per-repo gh account selection

### DIFF
--- a/zsh/gh-account
+++ b/zsh/gh-account
@@ -1,0 +1,18 @@
+# Per-repo gh account selection.
+#
+# gh has no native per-repository account binding: cli/cli treats
+# pwd/remote-based switching as out of scope, and `gh auth switch` only
+# flips one global active account (which reverts to the work EMU default
+# in fresh shells). This wrapper sets GH_TOKEN for a single gh invocation,
+# picking the account whose token matches the current repo's git
+# user.email — the same identity git+ssh already resolve per repo.
+gh() {
+  local email account
+  email=$(git config user.email 2>/dev/null)
+  case "$email" in
+    ladislav@prskavec.net)     account=abtris ;;
+    lprskavec@purestorage.com) account=lprskavec_pure ;;
+    *) command gh "$@"; return ;;
+  esac
+  GH_TOKEN=$(command gh auth token --user "$account" 2>/dev/null) command gh "$@"
+}

--- a/zshrc-ohmyzsh
+++ b/zshrc-ohmyzsh
@@ -36,6 +36,7 @@ export ZSH_HIGHLIGHT_HIGHLIGHTERS_DIR=/usr/local/share/zsh-syntax-highlighting/h
 source $ZSH/oh-my-zsh.sh
 source ~/bin/dotfiles/zsh/aliases
 source ~/bin/dotfiles/zsh/env
+source ~/bin/dotfiles/zsh/gh-account
 # brew install zsh-autosuggestions
 if [[ "$ARCH" == "arm64" ]]; then
   source /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh


### PR DESCRIPTION
Makes `gh` pick the right GitHub account per repo, the same way git+ssh already resolve identity per repo.

**Problem:** `gh` has no native per-repository account binding — cli/cli treats pwd/remote-based switching as out of scope, and `gh auth switch` only flips one global active account, which reverts to the work EMU default in fresh shells. The practical bite: running `gh pr create` in a personal repo fails with `Unauthorized: As an Enterprise Managed User, you cannot access this content` unless you remember to switch first.

**Fix:** a `gh` wrapper (`zsh/gh-account`, sourced from `zshrc-ohmyzsh`) that sets `GH_TOKEN` for a single invocation, choosing the account whose stored token matches the current repo's `git config user.email`. `GH_TOKEN` takes precedence over the active account, so this needs no `gh auth switch` and never mutates global state. Directories outside a known repo fall through to the default active account untouched.

Verified: `gh api /user` returns `abtris` inside a personal repo and the EMU account outside one, with no change to `gh auth switch`.
