### PR TITLE
Make pre-push hook non-interactive friendly

### DIFF
--- a/git/.gittemplate/hooks/pre-push
+++ b/git/.gittemplate/hooks/pre-push
@@ -1,18 +1,33 @@
 #!/usr/bin/env bash
 
 protected_branch='master'
-current_branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
-RANDOM_CHAR=$(( ( RANDOM % 10 )  + 1 ))
+current_branch=$(git symbolic-ref --short HEAD)
 
-if [ $protected_branch = $current_branch ]
+if [ "$protected_branch" != "$current_branch" ]
 then
-    read -p "You're about to push master, is that what you intended? [$RANDOM_CHAR|n] " -n 1 -r < /dev/tty
-    echo
-    if echo $REPLY | grep -E "^[$RANDOM_CHAR]$" > /dev/null
+    exit 0 # push will execute
+fi
+
+# git gives the hook the ref list on stdin, so [ -t 0 ] is never true here;
+# probing /dev/tty is the only way to tell an interactive shell from an
+# agent/CI one. Without it, `read < /dev/tty` used to die with
+# "Device not configured" and block the push with no explanation.
+if ! { true < /dev/tty; } 2>/dev/null
+then
+    if [ -n "$GIT_ALLOW_PROTECTED_PUSH" ]
     then
         exit 0 # push will execute
     fi
+    echo "pre-push: refusing to push '$protected_branch' from a non-interactive shell." >&2
+    echo "pre-push: branch and open a PR instead, or set GIT_ALLOW_PROTECTED_PUSH=1 to override." >&2
     exit 1 # push will not execute
-else
+fi
+
+RANDOM_CHAR=$(( ( RANDOM % 10 )  + 1 ))
+read -p "You're about to push master, is that what you intended? [$RANDOM_CHAR|n] " -n 1 -r < /dev/tty
+echo
+if echo "$REPLY" | grep -E "^[$RANDOM_CHAR]$" > /dev/null
+then
     exit 0 # push will execute
 fi
+exit 1 # push will not execute


### PR DESCRIPTION
**Problem**

`git/.gittemplate/hooks/pre-push` guards pushes to `master` with a confirm prompt read from `/dev/tty`. An agent or CI shell has no controlling terminal, so the redirect fails with `/dev/tty: Device not configured`, `read` returns nonzero, `$REPLY` is empty, and git rejects the push — with no indication of why.

**Change**

Probe `/dev/tty` before prompting. `[ -t 0 ]` is no help here: git hands the hook its ref list on stdin, so stdin is never a terminal even interactively.

- Terminal available → prompt exactly as before, unchanged behavior.
- No terminal → refuse the push and say so, pointing at branch-and-PR as the intended path.
- `GIT_ALLOW_PROTECTED_PUSH=1` overrides in the non-interactive case, so automation can push `master` deliberately but never by accident.

Also quoted `$current_branch` in the comparison and switched to `git symbolic-ref --short` instead of piping through `sed`.

**Verification**

Throwaway repos with the hook installed, driven non-interactively and under a pty via `script`:

| case | expected | result |
| --- | --- | --- |
| on `master`, no tty, no override | exit 1 + message | pass |
| on `master`, no tty, override set | exit 0 | pass |
| on a feature branch | exit 0, silent | pass |
| real `git push origin master`, no tty | rejected | pass |
| same push, override set | succeeds | pass |
| on `master` under a pty, answer `n` | prompt shown, exit 1 | pass |
| `shellcheck` | clean | pass |

`init.templatedir` only copies hooks at `git init` / `git clone`, so existing repos keep their old copy. To pick this up in a repo that already exists:

    cp ~/bin/dotfiles/git/.gittemplate/hooks/pre-push <repo>/.git/hooks/pre-push
