### PR TITLE
Fix secret scanning, executable linting and JS checks in hooks

### DIFF
--- a/git/.gittemplate/hooks/commit-msg
+++ b/git/.gittemplate/hooks/commit-msg
@@ -1,2 +1,9 @@
 #!/usr/bin/env bash
+# Skip rather than fail when git-secrets is absent: this hook is installed
+# globally via init.templatedir, so a bare `git secrets ...` made every commit
+# on a machine without it fail with "'secrets' is not a git command".
+if ! command -v git-secrets >/dev/null 2>&1; then
+  echo "WARNING: git-secrets is not installed, commit-msg scanning SKIPPED." >&2
+  exit 0
+fi
 git secrets --commit_msg_hook -- "$@"

--- a/git/.gittemplate/hooks/pre-commit
+++ b/git/.gittemplate/hooks/pre-commit
@@ -7,7 +7,6 @@
 #
 # Copyright 2013, kvz (http://twitter.com/kvz)
 # Adding https://github.com/awslabs/git-secrets
-git secrets --pre_commit_hook -- "$@"
 
 set -o pipefail
 set -o errexit
@@ -16,6 +15,18 @@ set -o nounset
 __DIR__="$(cd "$(dirname "${0}")"; echo $(pwd))"
 __BASE__="$(basename "${0}")"
 __FILE__="${__DIR__}/${__BASE__}"
+
+# Scan for secrets before the syntax checks. This used to run above the
+# `set -o` lines with its exit status untested, so a matched secret printed
+# git-secrets' error block and the commit still succeeded.
+if command -v git-secrets >/dev/null 2>&1; then
+  if ! git secrets --pre_commit_hook -- "$@"; then
+    exit 1
+  fi
+else
+  echo "WARNING: git-secrets is not installed, secret scanning SKIPPED." >&2
+  echo "WARNING: install it with 'brew install git-secrets' to re-enable." >&2
+fi
 
 if [ -x "${__DIR__}/pre-ochtra" ]; then
   echo "Running pre-ochtra"
@@ -72,10 +83,21 @@ git diff-index --cached --full-index --diff-filter=ACM $against |while read -r l
   fi
 
   she=""
-  # only check shebang on normal and executable files
-  if [ "${mod}" = "100644" ] || [ "${mod}" = "100664" ] || [ "${mod}" = "100455" ]; then
-    she="$(head -n1 ${pth} |awk -F/ '/^#\!/ {print $NF}' |sed 's/^env //g')"
-  fi
+  # Only check the shebang on regular files: 100644 and 100755. Git's other
+  # modes are symlinks (120000) and submodules (160000). The old test listed
+  # 100455 (a typo) and 100664 (not a git mode) and omitted 100755, so
+  # executable scripts were skipped entirely -- and those are usually
+  # extensionless, making the shebang their only signal.
+  #
+  # Read the staged blob, not the working tree, to stay consistent with the
+  # checks below. awk must drain stdin: `head -n1` closes the pipe early and
+  # SIGPIPEs git cat-file on blobs over the pipe buffer, which `set -o
+  # pipefail` then turns into a hook failure (exit 141).
+  case "${mod}" in
+    100*)
+      she="$(git cat-file -p "${sha}" |awk -F/ 'NR==1 && /^#\!/ {print $NF}' |sed 's/^env //g')"
+      ;;
+  esac
   out="purge"
   err="red"
   cmd=""
@@ -84,17 +106,21 @@ git diff-index --cached --full-index --diff-filter=ACM $against |while read -r l
   # Select linting tool based on extension or shebang
   if [ "${ext}" = "rb" ] || [ "${ext}" = "erb" ] || [ "${she}" = "ruby" ]; then
     cmd="ruby -c -"
-  elif [ "${ext}" = "js" ] || [ "${she}" = "node" ]; then
-    # jshint unfortunately uses STDOUT for errors, so paint all red
-    cmd="jshint -"
-    out="red"
-  elif [ "${ext}" = "es6" ] || [ "${she}" = "node" ]; then
-    # eslint need to be in localfolder, for example using npm install peasant
-    # if use global installed eslint not works with .eslintrc
-    # cmd="node_modules/.bin/eslint --stdin"
-    # or use global without .eslintrc
-    cmd="eslint --stdin --no-eslintrc"
-    out="red"
+  elif [ "${ext}" = "js" ] || [ "${ext}" = "mjs" ] || [ "${ext}" = "cjs" ] \
+       || [ "${ext}" = "es6" ] || [ "${she}" = "node" ]; then
+    # node --check parses with V8 itself, so it tracks current syntax (ESM,
+    # class fields, optional chaining) with no configuration. jshint read the
+    # blob from stdin, could not resolve a .jshintrc from there, defaulted to
+    # ES5, and so rejected valid modern JavaScript. Note this checks syntax
+    # only -- it makes no style judgements, which is what this hook is for.
+    # node rejects unknown extensions, so .es6 becomes .js for the temp file;
+    # .mjs and .cjs keep theirs because the extension carries module semantics.
+    if [ "${ext}" = "mjs" ] || [ "${ext}" = "cjs" ]; then
+      tmp="${TMPDIR:-/tmp}/${$}.${ext}"
+    else
+      tmp="${TMPDIR:-/tmp}/${$}.js"
+    fi
+    cmd="node --check ${tmp}"
   elif [ "${ext}" = "ts" ] ; then
     tmp="${TMPDIR:-/tmp}/${$}.${ext}"
     cmd="tslint ${tmp}"

--- a/git/.gittemplate/hooks/prepare-commit-msg
+++ b/git/.gittemplate/hooks/prepare-commit-msg
@@ -1,2 +1,6 @@
 #!/usr/bin/env bash
+# Skip rather than fail when git-secrets is absent -- see commit-msg.
+if ! command -v git-secrets >/dev/null 2>&1; then
+  exit 0
+fi
 git secrets --prepare_commit_msg_hook -- "$@"


### PR DESCRIPTION
Review of the remaining `.gittemplate` hooks, prompted by jshint rejecting valid JavaScript. Four bugs, each confirmed by running the hook rather than by reading it.

## 1. `git secrets` could never block a commit

`pre-commit` ran `git secrets --pre_commit_hook` above the `set -o` lines with its exit status untested. Staging a file matching a registered pattern printed the full `[ERROR] Matched one or more prohibited patterns` block and then committed anyway — exit 0, secret in `HEAD`. The loud error made it look like the guard worked.

Now `command -v git-secrets` gates it and a match exits 1.

## 2. `chmod +x` disabled syntax checking

Shebang detection was gated on mode `100644`, `100664`, or `100455`. Git's executable mode is `100755`; `100455` is a typo for it and `100664` is not a git mode. Since extensionless scripts are dispatched purely by shebang, every executable script skipped linting. A file containing `if [ x ; then` committed clean at 100755 and was caught at 100644.

Now matches `100*`, which covers both regular modes while still excluding symlinks (120000) and submodules (160000).

The shebang also came from the working tree via `head -n1 ${pth}`, unlike every other check, which reads the staged blob. That is wrong for partially staged files. Switching it to `git cat-file` needed care: `head -n1` closes the pipe early and SIGPIPEs `git cat-file`, which `pipefail` turns into a hook failure — exit 141 on a 9 MB blob, the same trap documented further down the file. `awk 'NR==1 && /^#\!/'` drains stdin instead.

## 3. jshint rejected all modern JavaScript

`.js` went to `jshint -` over stdin, where jshint cannot resolve a `.jshintrc` and falls back to ES5. `const`, arrows, template literals, `class`, `async`, `export` produced 6 errors on a valid file. All six of my test files failed, including plain CommonJS.

Replaced with `node --check`, which parses with V8, needs no configuration, tracks current syntax, and makes no style judgements — matching what this hook claims to do. Node was already a dependency, since jshint runs on it. Extended to `.mjs` and `.cjs`.

Known gap: JSX in a `.js` file now fails. It failed under jshint too, so nothing regresses.

## 4. The eslint branch was unreachable

`[ "${ext}" = "es6" ] || [ "${she}" = "node" ]` sat below a branch that already caught node shebangs, so only a literal `.es6` extension reached it — and eslint is not installed here, so it exited 1 demanding an install. Folded `.es6` into the node branch and dropped the branch.

## 5. `commit-msg` blocked every commit without git-secrets

The inverse of finding 1. These hooks install globally via `init.templatedir`, and `git secrets ...` fails with `'secrets' is not a git command` when it is absent, so committing broke entirely on a machine without it. Both message hooks now warn and exit 0.

## Verification

24 assertions against throwaway repos, driving the hooks through `git hook run` and real `git commit`:

| group | assertions |
| --- | --- |
| secret staged: hook rejects, `git commit` refused, `HEAD` unchanged | 2 |
| broken and valid bash at mode 100755 | 2 |
| 9 MB shebang script accepted, no SIGPIPE | 1 |
| ES2022 CommonJS, ESM-in-`.js`, `.mjs`, `.cjs`, `.es6`, broken `.js` | 6 |
| all three hooks exit 0 without git-secrets, warning on stderr | 2 |
| python, yaml, json, go still pass and fail correctly; binary skipped | 7 |
| `shellcheck -S error` on all four hooks | 4 |

## Left alone

`pylint` and `tslint` run against a temp file in `TMPDIR`, so they lose the project's config and import context and can report false errors at E level. Fixing that means resolving config per repo, which is a bigger change than this PR. Separately, the `python` shebang test does not match `python3`.

## Propagation

`init.templatedir` only copies hooks at `git init` / `git clone`, so existing repos keep the old versions:

    cp ~/bin/dotfiles/git/.gittemplate/hooks/{pre-commit,commit-msg,prepare-commit-msg} <repo>/.git/hooks/
