### PR TITLE
Fix nvim-lint erroring on missing markdownlint binary

### DIFF
--- a/nvim/lua/plugins/linting.lua
+++ b/nvim/lua/plugins/linting.lua
@@ -1,4 +1,10 @@
--- nvim-lint: linters that run alongside the LSP. golangci-lint for Go.
+-- nvim-lint: linters that run alongside the LSP. golangci-lint for Go,
+-- markdownlint-cli2 for Markdown.
+--
+-- The autocmd only runs linters whose executable is actually present, so a
+-- missing tool degrades to "no linting" instead of throwing an error on every
+-- save (which is what happened when this pointed at `markdownlint`, a binary
+-- that was not installed).
 return {
   "mfussenegger/nvim-lint",
   event = { "BufReadPost", "BufWritePost", "InsertLeave" },
@@ -6,12 +12,29 @@ return {
     local lint = require("lint")
     lint.linters_by_ft = {
       go = { "golangcilint" },
-      markdown = { "markdownlint" },
+      markdown = { "markdownlint-cli2" },
     }
+
+    local function runnable_linters()
+      local names = lint.linters_by_ft[vim.bo.filetype] or {}
+      local ok = {}
+      for _, name in ipairs(names) do
+        local linter = lint.linters[name]
+        local cmd = linter and (type(linter.cmd) == "function" and linter.cmd() or linter.cmd)
+        if cmd and vim.fn.executable(cmd) == 1 then
+          table.insert(ok, name)
+        end
+      end
+      return ok
+    end
+
     vim.api.nvim_create_autocmd({ "BufWritePost", "BufReadPost", "InsertLeave" }, {
       group = vim.api.nvim_create_augroup("nvim-lint", { clear = true }),
       callback = function()
-        require("lint").try_lint()
+        local names = runnable_linters()
+        if #names > 0 then
+          lint.try_lint(names)
+        end
       end,
     })
   end,

--- a/nvim/lua/plugins/lsp.lua
+++ b/nvim/lua/plugins/lsp.lua
@@ -93,6 +93,7 @@ return {
         "gofumpt",
         "golangci-lint",
         "delve",
+        "markdownlint-cli2",
       },
     })
   end,


### PR DESCRIPTION
Opening `README.md` (any Markdown file) threw an error.

**Cause:** `linting.lua` configured the `markdownlint` linter, but that binary is not installed here — the machine has `markdownlint-cli2` (Brewfile.work). nvim-lint spawned a missing command and errored on every Markdown buffer.

**Fix:**
- switch the Markdown linter to `markdownlint-cli2` (the tool that is actually present)
- add `markdownlint-cli2` to mason `ensure_installed`, so it is installed on any machine regardless of which Brewfile ran
- guard the lint autocmd to run only linters whose executable resolves — a missing tool now degrades to no linting instead of throwing on save. This prevents the whole class of error, not just this one.

**Verified headless:**
- markdownlint-cli2 produces diagnostics through nvim-lint on a file with violations (MD022 blanks-around-headings, MD025 multiple H1)
- a clean file and the actual README report zero diagnostics
- no error raised; executable guard resolves `markdownlint-cli2` on nvim's PATH

Fix is already applied to the live config on this machine via the symlink, so the error is gone now.
