### PR TITLE
Add pureclone helper for cloning Pure GitHub repos

### DIFF
--- a/zsh/pureclone
+++ b/zsh/pureclone
@@ -1,0 +1,34 @@
+# Clone a Pure GitHub repo through the `github-pure` ssh alias.
+#
+# The bare `org-144335849@github.com:org/repo.git` URL connects to host
+# `github.com`, so it matches the `Host github.com` block in ~/.ssh/config —
+# which pins IdentityAgent to the 1Password agent. That agent does not hold
+# the short-lived keymaster certs `purelogin` mints, and IdentityAgent
+# replaces the agent rather than adding to it, so the org rejects the
+# connection with `Permission denied (publickey)`. The `github-pure` alias
+# has no IdentityAgent override, falls back to the default agent, and works.
+#
+#   pureclone github-double            -> pure-prod-krypton/github-double
+#   pureclone some-org/some-repo
+#   pureclone https://github.com/pure-prod-krypton/github-double.git
+pureclone() {
+  local repo=$1
+  if [ -z "$repo" ]; then
+    echo "usage: pureclone <repo|org/repo|url> [git clone args...]" >&2
+    return 2
+  fi
+  shift
+  repo=${repo#https://github.com/}
+  repo=${repo#*@github.com:}
+  repo=${repo%.git}
+  case "$repo" in
+    */*) ;;
+    *) repo=pure-prod-krypton/$repo ;;
+  esac
+  git clone "github-pure:$repo.git" "$@" || {
+    local rc=$?
+    ssh-add -l >/dev/null 2>&1 ||
+      echo "pureclone: ssh agent holds no identities — run \`purelogin\` to mint fresh GitHub certs" >&2
+    return $rc
+  }
+}

--- a/zshrc-ohmyzsh
+++ b/zshrc-ohmyzsh
@@ -37,6 +37,7 @@ source $ZSH/oh-my-zsh.sh
 source ~/bin/dotfiles/zsh/aliases
 source ~/bin/dotfiles/zsh/env
 source ~/bin/dotfiles/zsh/gh-account
+source ~/bin/dotfiles/zsh/pureclone
 # brew install zsh-autosuggestions
 if [[ "$ARCH" == "arm64" ]]; then
   source /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh


### PR DESCRIPTION
Adds a `pureclone` shell function so I don't have to remember which SSH alias a Pure repo needs.

**Why**

Cloning with the URL GitHub hands you — `org-144335849@github.com:pure-prod-krypton/repo.git` — fails with `Permission denied (publickey)` even with admin rights on the repo. The host being connected to is literally `github.com`, so the `Host github.com` block in `~/.ssh/config` applies and pins `IdentityAgent` to the 1Password agent. That agent doesn't hold the short-lived keymaster certs `purelogin` mints, and `IdentityAgent` *replaces* the agent rather than adding to it, so the cert is never offered.

The `github-pure` alias has no `IdentityAgent` override, falls back to the default agent, and authenticates fine. `pureclone` just routes every clone through it.

**Usage**

```
pureclone github-double                                        # -> pure-prod-krypton/github-double
pureclone some-org/some-repo
pureclone https://github.com/pure-prod-krypton/github-double.git
pureclone github-double ~/Sites/gh-double --depth 1            # extra args pass through to git clone
```

Defaults the org to `pure-prod-krypton`, accepts `org/repo` or a full HTTPS/SSH URL, and passes trailing args straight to `git clone`. On failure it checks whether the agent is empty and, if so, points at `purelogin` — the daily expiry is the common cause.

**Testing**

Verified all three input forms clone successfully, that extra args pass through, and that the no-arg usage message works under both bash and zsh.
