### PR TITLE
Show the Jira issue behind the current PR in the Herdr agent sidebar

### DIFF
--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -13,3 +13,19 @@ next_workspace = "prefix+down"
 key = "cmd+p"
 type = "shell"
 command = "herdr plugin action invoke cloudmanic.herdr-plus.projects"
+
+[[keys.command]]
+key = "prefix+j"
+type = "plugin_action"
+command = "abtris.jira-pr.refresh-forced"
+description = "refresh Jira/PR line"
+
+# $jira comes from the abtris.jira-pr plugin: the Jira issue behind the current
+# branch's PR, or a warning when the branch and the PR name different issues.
+# Declaring rows replaces the defaults, so the first two lines repeat them.
+[ui.sidebar.agents]
+rows = [
+  ["state_icon", "workspace", "tab"],
+  ["agent"],
+  ["$jira"],
+]


### PR DESCRIPTION
Adds a third Agent sidebar row showing the Jira issue behind the current branch's pull request, plus `prefix+j` to refresh it on demand.

The value comes from a new plugin, `abtris.jira-pr`, which reports it as pane metadata under the `$jira` token. The plugin resolves candidate issue keys from the branch name, PR title, and PR body, checks each against Jira, and shows the first one that exists:

    ● claude · working
      #45 KR-1234 Fix the retry loop · In Review
      krypton-kag · shell

When the branch and the PR each name a different real issue — a PR linked to the wrong ticket — the row warns instead:

    ⚠ #45 KR-1234 (branch) ≠ KR-1240 (PR)

Two notes on this config:

- Declaring `[ui.sidebar.agents].rows` replaces Herdr's defaults rather than extending them, so the first two lines repeat the defaults verbatim.
- The `prefix+j` binding and the `$jira` token both need the plugin linked (`herdr plugin install abtris/herdr-plugin-jira-pr`). Without it the row simply disappears, since Herdr drops unreported custom tokens.
