### PR TITLE
Bind the Jira/PR popup to cmd+j instead of a dead prefix key

### DIFF
--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -14,11 +14,16 @@ key = "cmd+p"
 type = "shell"
 command = "herdr plugin action invoke cloudmanic.herdr-plus.projects"
 
+# Opens the Jira/PR popup: open the PR or issue in a browser, assign a ticket by
+# hand, refresh. A direct cmd+ chord on purpose — Herdr binds no cmd+ keys, while
+# most prefix+ letters are taken, and a custom binding that collides with a
+# built-in is silently disabled (prefix+j is focus_pane_down, prefix+o is
+# open_notification_target).
 [[keys.command]]
-key = "prefix+j"
-type = "plugin_action"
-command = "abtris.jira-pr.refresh-forced"
-description = "refresh Jira/PR line"
+key = "cmd+j"
+type = "shell"
+command = "herdr plugin pane open --plugin abtris.jira-pr --entrypoint menu"
+description = "Jira/PR popup"
 
 # $jira comes from the abtris.jira-pr plugin: the Jira issue behind the current
 # branch's PR, or a warning when the branch and the PR name different issues.


### PR DESCRIPTION
The `prefix+j` binding added in #48 never worked. `prefix+j` is Herdr's built-in `focus_pane_down`, and a custom binding that collides with a built-in is silently disabled — no error, the key keeps doing its old job. `prefix+o`, which the plugin README suggested, is `open_notification_target` and fails the same way.

Replaced with `cmd+j`, matching how `cmd+p` already invokes herdr-plus here. Herdr binds no `cmd+` keys by default, so the chord is free, and neither `super+j` nor `super+p` is bound in the Ghostty config, so it reaches Herdr.

It now opens the plugin's popup rather than firing a single action, so one key covers opening the PR in a browser, opening the Jira issue, assigning a ticket by hand, and refreshing:

    Jira PR — lprskavec/KR-14644-saas-reservation-backfill-schedule

    p  #3346 KR-14644 [KIM-KAG] Legacy SaaS backfilling · In Progress
    j  KR-14644 in Jira
    a  assign a ticket…
    r  refresh now

    esc  cancel

Needs abtris/herdr-plugin-jira-pr#5 merged and the plugin reinstalled, since `r` in the popup lands there.
