### PR TITLE
Show prompt-cache TTL countdown in the herdr agent sidebar

### DIFF
--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -28,5 +28,19 @@ description = "Jira/PR popup"
 # $jira comes from the abtris.jira-pr plugin: the Jira issue behind the current
 # branch's PR, or a warning when the branch and the PR name different issues.
 # Declaring rows replaces the defaults, so the first two lines repeat them.
+#
+# The three $cache_* tokens come from the cache-ttl plugin and are mutually
+# exclusive — exactly one renders, picked by the prompt cache's remaining TTL
+# (green, amber under 10 minutes, red under 5 or expired). All three go on the
+# agent row so the countdown sits beside the agent it belongs to.
 [ui.sidebar.agents]
-rows = [["state_icon", "workspace", "tab"], ["agent"], ["$jira"]]
+rows = [
+  ["state_icon", "workspace", "tab"],
+  [
+    "agent",
+    { token = "$cache_ok", fg = "#4ade80" },
+    { token = "$cache_warn", fg = "#f59e0b" },
+    { token = "$cache_crit", fg = "#ef4444" },
+  ],
+  ["$jira"],
+]


### PR DESCRIPTION
Adds the prompt-cache countdown to the herdr agent sidebar, via the `cache-ttl` plugin (`nytafar/herdr-cache-ttl`, installed separately with `herdr plugin install nytafar/herdr-cache-ttl --yes`).

The plugin exposes `$cache_ok`, `$cache_warn` and `$cache_crit`. They are mutually exclusive — exactly one renders, picked by how much prompt-cache TTL is left (green, amber under 10 minutes, red under 5 or expired). All three sit on the agent row so the countdown lands beside the agent it describes; the existing `$jira` row is unchanged.

Declaring `rows` replaces the defaults wholesale, so the array is spelled out in full. Verified with `herdr server reload-config`: `status: applied`, no diagnostics.
