### PR TITLE
Install herdr plugins from the dotfiles installer

### DIFF
--- a/install
+++ b/install
@@ -103,6 +103,7 @@ else
 abtris/herdr-plugin-jira-pr
 cloudmanic/herdr-plus
 nytafar/herdr-cache-ttl
+smarzban/herdr-file-viewer
 EOF
 fi
 

--- a/install
+++ b/install
@@ -72,4 +72,38 @@ themes/abtris.zsh-theme|.oh-my-zsh/custom/themes/abtris.zsh-theme
 custom/plugins/abtris|.oh-my-zsh/custom/plugins/abtris
 EOF
 
+# herdr plugins are fetched from GitHub and built on the machine, so they are
+# installed rather than symlinked. Reinstalling the same source is also how
+# herdr upgrades a plugin in place, which keeps this idempotent. Set
+# DOTFILES_SKIP_HERDR_PLUGINS=1 to skip the network and build work; test-install
+# does that so the symlink checks stay fast and offline.
+# herdr prints a multi-line install preview even on success, which would bury
+# the one-line-per-item output above. Buffer it and replay it only on failure,
+# so real errors still reach the terminal.
+herdr_plugin() {
+  if herdr plugin install "$1" --yes >"$plugin_log" 2>&1; then
+    printf 'plugin   %s\n' "$1"
+  else
+    printf 'failed   %s\n' "$1" >&2
+    cat "$plugin_log" >&2
+    status=1
+  fi
+}
+
+if [ "${DOTFILES_SKIP_HERDR_PLUGINS:-0}" = 1 ]; then
+  printf 'skipped  herdr plugins (DOTFILES_SKIP_HERDR_PLUGINS)\n'
+elif ! command -v herdr >/dev/null; then
+  printf 'skipped  herdr plugins (herdr not installed)\n'
+else
+  plugin_log=$(mktemp)
+  trap 'rm -f "$plugin_log"' EXIT
+  while read -r plugin; do
+    herdr_plugin "$plugin"
+  done <<'EOF'
+abtris/herdr-plugin-jira-pr
+cloudmanic/herdr-plus
+nytafar/herdr-cache-ttl
+EOF
+fi
+
 exit "$status"

--- a/test-install
+++ b/test-install
@@ -5,13 +5,13 @@ root=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 test_home=$(mktemp -d)
 trap 'rm -rf "$test_home"' EXIT
 
-HOME=$test_home "$root/install" >/dev/null
-HOME=$test_home "$root/install" >/dev/null
+HOME=$test_home DOTFILES_SKIP_HERDR_PLUGINS=1 "$root/install" >/dev/null
+HOME=$test_home DOTFILES_SKIP_HERDR_PLUGINS=1 "$root/install" >/dev/null
 test "$(readlink "$test_home/.zshrc")" = "$root/zshrc-ohmyzsh"
 
 rm "$test_home/.zshrc"
 : >"$test_home/.zshrc"
-if HOME=$test_home "$root/install" >/dev/null 2>&1; then
+if HOME=$test_home DOTFILES_SKIP_HERDR_PLUGINS=1 "$root/install" >/dev/null 2>&1; then
   echo 'install did not report a conflict' >&2
   exit 1
 fi


### PR DESCRIPTION
The installer only symlinked config files, so a fresh machine ended up with `herdr/config.toml` and nothing behind it — the `$jira` and `$cache_*` sidebar rows landed from #52 referencing tokens no installed plugin published. This installs the four plugins the config actually depends on:

- `abtris/herdr-plugin-jira-pr` — publishes `$jira`
- `cloudmanic/herdr-plus` — Projects and Quick Actions, bound to `cmd+p`
- `nytafar/herdr-cache-ttl` — publishes `$cache_ok` / `$cache_warn` / `$cache_crit`
- `smarzban/herdr-file-viewer` — git-aware file viewer, bound to `cmd+f` in #54

Sources match what `herdr plugin list` records, and reinstalling a source is how herdr upgrades in place, so rerunning the installer is idempotent. Verified: two consecutive runs both exit 0.

Two details worth knowing. herdr prints a multi-line install preview on success, which buried the one-line-per-item output the script is built around, so the step buffers that output and replays it only when a plugin fails — a bad source still prints its error and sets a nonzero exit. And `DOTFILES_SKIP_HERDR_PLUGINS=1` skips the step entirely; `test-install` sets it, because it runs the installer twice against a throwaway `$HOME` and would otherwise trigger network fetches and a build on every test run.

The step is skipped with a message when `herdr` is not on `PATH`, so machines without herdr are unaffected.
