### PR TITLE
Bind the herdr file viewer to cmd+o and cmd+shift+o

### DIFF
--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -25,6 +25,24 @@ type = "shell"
 command = "herdr plugin pane open --plugin abtris.jira-pr --entrypoint menu"
 description = "Jira/PR popup"
 
+# The file viewer opens only from these keys — its manifest declares no event
+# hooks, so nothing spawns it unasked. cmd+ chords again, for the reason above.
+# Not the README's prefix+f (silent-collision trap), and not cmd+f/cmd+shift+f
+# either: Ghostty takes those for start_search / end_search and consumes them
+# before herdr sees them. `ghostty +list-keybinds` is the way to check — the
+# keybind lines in ghostty/config are overrides and do not list the defaults.
+[[keys.command]]
+key = "cmd+o"
+type = "plugin_action"
+command = "herdr-file-viewer.open-file-viewer"
+description = "File viewer (split)"
+
+[[keys.command]]
+key = "cmd+shift+o"
+type = "plugin_action"
+command = "herdr-file-viewer.open-file-viewer-tab"
+description = "File viewer (tab)"
+
 # $jira comes from the abtris.jira-pr plugin: the Jira issue behind the current
 # branch's PR, or a warning when the branch and the PR name different issues.
 # Declaring rows replaces the defaults, so the first two lines repeat them.


### PR DESCRIPTION
Binds the `herdr-file-viewer` plugin (`smarzban/herdr-file-viewer`) to `cmd+o` for a split pane and `cmd+shift+o` for its own tab. Installed separately; PR #53 adds it to the installer.

This replaces the herdr-sidebar attempt. That plugin hard-wired five `[[events]]` hooks — `pane.focused`, `tab.created`, `tab.focused`, `workspace.created`, `workspace.focused` — each re-opening the sidebar, with no config key or env var to gate them. The file viewer declares zero event hooks by design, so it appears only when one of these keys is pressed.

`cmd+` chords rather than the plugin README's `prefix+f`, for the reason already recorded above the `cmd+j` binding: a custom `prefix+` binding that collides with a built-in is silently disabled, and herdr offers no way to list its built-ins to check.

`cmd+o` rather than the obvious `cmd+f`, because Ghostty binds `super+f=start_search` and `super+shift+f=end_search` by default and consumes both before herdr sees them. The `keybind` lines in `ghostty/config` are overrides and say nothing about the defaults, so checking them is not enough — `ghostty +list-keybinds` is. `super+o` and `super+shift+o` appear in neither the defaults nor the overrides.

Verified: action ids match `herdr plugin action list`, `herdr config check` reports ok, and `herdr server reload-config` applied with no diagnostics.

Markdown files render through `glow`, which is not installed here — the viewer falls back to plain text until it is.
