### PR TITLE
Lay out the ask prompt so it can be read at a glance

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,14 @@ label. The guard checks every plain pattern before any `ask:` pattern, so a
 command that trips both gets denied rather than offered. The prompt is a local
 addition to the upstream hook, using the Claude Code `permissionDecision` field.
 
+On an `ask:` line, ` ::: ` ends the regex and starts a note, which the prompt
+shows above the approve and deny guidance. Write the note as the thing that is
+hard to undo, since that is the decision:
+
+```
+ask:<regex> ::: Deletes a label you can recreate, or a secret you cannot.
+```
+
 Edit the denylist to tune it; changes apply to the next command, no restart.
 Then run the tests, which cover both payload shapes and all three verdicts:
 

--- a/agents/hooks/dangerous-patterns.txt
+++ b/agents/hooks/dangerous-patterns.txt
@@ -2,6 +2,7 @@
 # Vendored from https://github.com/davidondrej/skills/tree/main/hooks
 # One POSIX-ERE regex (grep -E) per line. Blank lines and # comments are ignored.
 # A line prefixed "ask:" prompts for confirmation instead of blocking outright.
+# On an ask: line, " ::: " ends the regex and starts a note shown in the prompt.
 # Shared by ALL agents: Cursor, Claude Code, Codex, OpenCode, Pi, Hermes.
 # Edit this file to tune; changes apply immediately (no restarts needed).
 # Adapters for Pi/OpenCode/Hermes convert [:space:] to \s automatically.
@@ -49,6 +50,6 @@
 (^|[;&|[:space:]])gh[[:space:]]+repo[[:space:]]+delete([[:space:]]|$)
 (^|[;&|[:space:]])gh[[:space:]]+release[[:space:]]+delete([[:space:]]|$)
 (^|[;&|[:space:]])gh[[:space:]]+(secret|ssh-key|gpg-key)[[:space:]]+delete([[:space:]]|$)
-ask:(^|[;&|[:space:]])gh[[:space:]]+api[[:space:]][^;&|]*(-X|--method)(=|[[:space:]]+)(DELETE|delete)
+ask:(^|[;&|[:space:]])gh[[:space:]]+api[[:space:]][^;&|]*(-X|--method)(=|[[:space:]]+)(DELETE|delete) ::: Deletes something on GitHub through the API. A label, comment or workflow run you can recreate — but the same call deletes a repo, release, secret or deploy key, and those do not come back.
 (^|[;&|[:space:]])gh[[:space:]]+repo[[:space:]]+edit[^;&|]*--visibility(=|[[:space:]]+)public
 (^|[;&|[:space:]])gh[[:space:]]+auth[[:space:]]+token([[:space:]]|$)

--- a/agents/hooks/deny-dangerous.sh
+++ b/agents/hooks/deny-dangerous.sh
@@ -42,30 +42,44 @@ CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // .toolInput.command //
 [ -z "$CMD" ] && allow
 [ -f "$PATTERNS_FILE" ] || allow
 
-# Prints the first pattern of the requested kind that matches, and returns 0.
-# $1 is "ask" to read only ask: lines, anything else to read only plain ones.
+# Sets MATCHED and MATCHED_NOTE to the first pattern of the requested kind that
+# matches, and returns 0. $1 is "ask" to read only ask: lines, anything else to
+# read only plain ones. Not called in a subshell, so the globals survive.
 first_match() {
+  MATCHED=
+  MATCHED_NOTE=
   while IFS= read -r line; do
     case "$line" in ''|\#*) continue ;; esac
     case "$line" in
       ask:*)
         [ "$1" = ask ] || continue
-        pattern=${line#ask:}
+        line=${line#ask:}
         ;;
       *)
         [ "$1" = ask ] && continue
+        ;;
+    esac
+    # " ::: " ends the regex and starts a human note. No ERE contains it.
+    case "$line" in
+      *" ::: "*)
+        pattern=${line%% ::: *}
+        note=${line#* ::: }
+        ;;
+      *)
         pattern=$line
+        note=
         ;;
     esac
     if printf '%s\n' "$CMD" | grep -qE -- "$pattern" 2>/dev/null; then
-      printf '%s' "$pattern"
+      MATCHED=$pattern
+      MATCHED_NOTE=$note
       return 0
     fi
   done < "$PATTERNS_FILE"
   return 1
 }
 
-if MATCHED=$(first_match deny); then
+if first_match deny; then
   if [ "$MODE" = "cursor" ]; then
     jq -cn --arg p "$MATCHED" '{
       permission: "deny",
@@ -78,20 +92,33 @@ if MATCHED=$(first_match deny); then
   exit 2
 fi
 
-if MATCHED=$(first_match ask); then
+if first_match ask; then
+  # Laid out for someone deciding in a hurry: what runs, what it costs, where the
+  # rule lives. No ANSI colour, because a prompt that renders escapes literally
+  # would show the bytes instead of the emphasis.
+  REASON=$(printf '%s\n' \
+    "**Command guard — this needs your decision.**" \
+    "" \
+    "- **Running:** \`$CMD\`" \
+    "${MATCHED_NOTE:+- **Risk:** $MATCHED_NOTE}" \
+    "- **Approve** if you recognise that target and can recreate it." \
+    "- **Deny** if a delete was not what you asked for. Nothing is retried behind your back." \
+    "" \
+    "Rule: \`ask:\` line in \`~/.agents/hooks/dangerous-patterns.txt\`")
+
   if [ "$MODE" = "cursor" ]; then
-    jq -cn --arg p "$MATCHED" '{
+    jq -cn --arg r "$REASON" '{
       permission: "ask",
-      user_message: "Command guard wants confirmation for a destructive command.",
-      agent_message: ("The global dangerous-command guard (~/.agents/hooks/dangerous-patterns.txt) asks before running this. Matched pattern: " + $p + ".")
+      user_message: $r,
+      agent_message: $r
     }'
     exit 0
   fi
-  jq -cn --arg p "$MATCHED" '{
+  jq -cn --arg r "$REASON" '{
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
       permissionDecision: "ask",
-      permissionDecisionReason: ("The global dangerous-command guard (~/.agents/hooks/dangerous-patterns.txt) asks before running this. Matched pattern: " + $p + ".")
+      permissionDecisionReason: $r
     }
   }'
   exit 0

--- a/agents/hooks/test-guard.sh
+++ b/agents/hooks/test-guard.sh
@@ -143,6 +143,17 @@ check allow 'git gc'
 check allow 'git gc --aggressive'
 check allow 'git gc --prune=2.weeks.ago'
 
+# ---- the ask prompt shows the command and the pattern's note ----
+reason=$(jq -cn '{tool_input:{command:"gh api -X DELETE /repos/example-org/example-repo"},cwd:"/tmp"}' \
+  | "$GUARD" | jq -r '.hookSpecificOutput.permissionDecisionReason')
+case "$reason" in
+  *"gh api -X DELETE /repos/example-org/example-repo"*"do not come back"*)
+    pass=$((pass+1)) ;;
+  *)
+    fail=$((fail+1))
+    echo "FAIL [ask reason] missing command or note: $reason" ;;
+esac
+
 echo ""
 echo "passed: $pass, failed: $fail"
 [ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
Follow-up to #55. The `ask:` prompt was one long line ending in a raw regex,
which is the least useful thing to show someone deciding whether to delete a
GitHub resource.

It now renders as a short list:

```
**Command guard — this needs your decision.**

- **Running:** `gh api -X DELETE /repos/abtris/dotfiles/labels/stale`
- **Risk:** Deletes something on GitHub through the API. A label, comment or
  workflow run you can recreate — but the same call deletes a repo, release,
  secret or deploy key, and those do not come back.
- **Approve** if you recognise that target and can recreate it.
- **Deny** if a delete was not what you asked for. Nothing is retried behind your back.

Rule: `ask:` line in `~/.agents/hooks/dangerous-patterns.txt`
```

The risk line comes from a per-pattern note, so each `ask:` rule explains its own
stakes rather than sharing generic wording. On an `ask:` line, ` ::: ` ends the
regex and starts the note. No ERE contains that sequence, and the parser strips
the note before matching.

No ANSI colour. A prompt that does not interpret escape codes would show the
bytes instead of the emphasis, which is worse than plain text.

`first_match` now sets globals instead of printing, since it has two values to
return and command substitution would have put them in a subshell.

**Verification**

- `agents/hooks/test-guard.sh` — 185 assertions pass, including a new one that
  fails if the prompt loses either the command or the note
- `./test-install` — passes
