### PR TITLE
fix(git): scope github https-to-ssh rewrite to owned namespaces

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -137,8 +137,10 @@
 	sort = version:refname	
 [url "git@github.com:abtris/"]
 	insteadOf = "gh:"
-[url "ssh://git@github.com/"]
-	insteadOf = https://github.com/
+[url "ssh://git@github.com/abtris/"]
+	insteadOf = https://github.com/abtris/
+[url "github-pure:pure-prod-krypton/"]
+	insteadOf = https://github.com/pure-prod-krypton/
 [credential "https://github.com"]
 	helper = 
 	helper = !/opt/homebrew/bin/gh auth git-credential


### PR DESCRIPTION
The blanket `url."ssh://git@github.com/".insteadOf = https://github.com/` rewrote *every* HTTPS GitHub URL to SSH, including third-party repos I have no key for — so cloning or fetching anything outside my own namespaces failed on publickey.

Narrow the rewrite to the two namespaces that actually have keys:

- `https://github.com/abtris/` → `ssh://git@github.com/abtris/`
- `https://github.com/pure-prod-krypton/` → `github-pure:pure-prod-krypton/` (work cert identity)

Everything else keeps its HTTPS URL and goes through the `gh` credential helper already configured below.
